### PR TITLE
Add Juju 3.4 support

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     needs: lint-unit
     strategy:
       fail-fast: false
@@ -35,7 +35,8 @@ jobs:
     with:
       command: ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}
-      nested-containers: true
+      nested-containers: false
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
+      runs-on: "['self-hosted', 'linux', 'x64', 'large']]"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       command: ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}
-      nested-containers: false
+      nested-containers: true
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,6 +10,10 @@ on:
       - "**.md"
       - "**.rst"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
@@ -19,27 +23,19 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
     strategy:
       fail-fast: false
+      matrix:
+        command: ["TEST_JUJU3=1 make functional"]  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+        juju-channel: ["3.4/stable"]
     with:
-      command: "make functional"
-      juju-channel: "3.1/stable"
+      command: ${{ matrix.command }}
+      juju-channel: ${{ matrix.juju-channel }}
       nested-containers: false
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
-      tox-version: "<4"
-      runs-on: "['self-hosted', 'runner-k8s-svc-check']"
-      action-operator: false
-      external-controller: true
-      juju-controller: soleng-ci-ctrl
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAo="
-    secrets:
-      juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
-      juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}
-      openstack-auth-env: ${{ secrets.OPENSTACK_AUTH_ENV }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 PYTHON := /usr/bin/python3
 
 PROJECTPATH=$(dir $(realpath $(MAKEFILE_LIST)))
-ifndef CHARM_BUILD_DIR
-	CHARM_BUILD_DIR=${PROJECTPATH}.build
-endif
 ifdef CONTAINER
 	BUILD_ARGS="--destructive-mode"
 endif
@@ -21,19 +18,16 @@ help:
 	@echo " make release - run clean, submodules and build targets"
 	@echo " make lint - run flake8 and black --check"
 	@echo " make black - run black and reformat files"
-	@echo " make proof - run charm proof"
 	@echo " make unittests - run the tests defined in the unittest subdirectory"
 	@echo " make functional - run the tests defined in the functional subdirectory"
 	@echo " make test - run lint, proof, unittests and functional targets"
 	@echo ""
 
 clean:
-	@echo "Cleaning files"
-	@git clean -ffXd -e '!.idea'
-	@echo "Cleaning existing build"
-	@rm -rf ${CHARM_BUILD_DIR}/${CHARM_NAME}
+	@echo "Cleaning ${PROJECTPATH}/${CHARM_NAME}*.charm files"
+	@rm -rf ${PROJECTPATH}/${CHARM_NAME}*.charm
+	@echo "Cleaning charmcraft"
 	@charmcraft clean
-	@rm -rf ${PROJECTPATH}/${CHARM_NAME}.charm
 
 submodules:
 	@echo "Cloning submodules"
@@ -44,29 +38,14 @@ submodules-update:
 	@git submodule update --init --recursive --remote --merge
 
 build: clean submodules-update
-	sudo apt install -y unzip
-	@echo "Building charm to base directory ${CHARM_BUILD_DIR}/${CHARM_NAME}"
+	@echo "Building charm to base directory ${PROJECTPATH}/${CHARM_NAME}.charm"
 	@-git rev-parse --abbrev-ref HEAD > ./repo-info
 	@-git describe --always > ./version
 	@charmcraft -v pack ${BUILD_ARGS}
 	@bash -c ./rename.sh
-	@mkdir -p ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@unzip ${PROJECTPATH}/${CHARM_NAME}.charm -d ${CHARM_BUILD_DIR}/${CHARM_NAME}
 
-
-release: clean build unpack
-	@echo "Charm is built at ${CHARM_BUILD_DIR}/${CHARM_NAME}"
-
-unpack: build
-	@-rm -rf ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@mkdir -p ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@echo "Unpacking built .charm into ${CHARM_BUILD_DIR}/${CHARM_NAME}"
-	@cd ${CHARM_BUILD_DIR}/${CHARM_NAME} && unzip -q ${CHARM_BUILD_DIR}/${CHARM_NAME}.charm
-	# until charmcraft copies READMEs in, we need to publish charms with readmes in them.
-	@cp ${PROJECTPATH}/README.md ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@cp ${PROJECTPATH}/copyright ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@cp ${PROJECTPATH}/repo-info ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@cp ${PROJECTPATH}/version ${CHARM_BUILD_DIR}/${CHARM_NAME}
+release: clean build
+	@echo "Charm is built at ${PROJECTPATH}/${CHARM_NAME}.charm"
 
 lint:
 	@echo "Running lint checks"
@@ -76,20 +55,16 @@ black:
 	@echo "Reformat files with black"
 	@tox -e black
 
-proof: unpack
-	@echo "Running charm proof"
-	@charm proof ${CHARM_BUILD_DIR}/${CHARM_NAME}
-
 unittests:
 	@echo "Running unit tests"
 	@tox -e unit
 
 functional: build
-	@echo "Executing functional tests in ${CHARM_BUILD_DIR}"
+	@echo "Executing functional tests with ${PROJECTPATH}/${CHARM_NAME}.charm"
 	@CHARM_LOCATION=${PROJECTPATH} tox -e func
 
-test: lint proof unittests functional
+test: lint unittests functional
 	@echo "Tests completed for charm ${CHARM_NAME}."
 
 # The targets below don't depend on a file
-.PHONY: help submodules submodules-update clean build release lint black proof unittests functional test unpack
+.PHONY: help submodules submodules-update clean build release lint black unittests functional test

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,7 +9,6 @@ tags:
     - kubernetes
     - ops
     - monitoring
-series: []
 requires:
     kube-control:
         interface: kube-control

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,3 +1,3 @@
 python-openstackclient
-git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -1,5 +1,6 @@
 applications:
     kubernetes-service-checks:
+        charm: kubernetes-service-checks
         num_units: 1
     containerd:
         charm: ch:containerd
@@ -16,10 +17,12 @@ applications:
         charm: ch:flannel
     kubernetes-master:
         charm: ch:kubernetes-control-plane
+        channel: 1.28/stable
         num_units: 1
         constraints: cores=4 mem=4G root-disk=16G
     kubernetes-worker:
         charm: ch:kubernetes-worker
+        channel: 1.28/stable
         expose: true
         # Note(sudeephb): Using only one worker instance
         # to put less stress on test environment

--- a/tests/functional/tests/bundles/overlays/jammy.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/jammy.yaml.j2
@@ -1,1 +1,14 @@
 series: jammy
+
+applications:
+    containerd:
+        series: focal
+    easyrsa:
+        series: focal
+    flannel:
+        series: focal
+    kubernetes-master:
+        series: focal
+    kubernetes-worker:
+        series: focal
+

--- a/tox.ini
+++ b/tox.ini
@@ -21,16 +21,8 @@ passenv =
   NO_PROXY
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
-  OS_REGION_NAME
-  OS_AUTH_VERSION
-  OS_AUTH_URL
-  OS_PROJECT_DOMAIN_NAME
-  OS_USERNAME
-  OS_PASSWORD
-  OS_PROJECT_ID
-  OS_USER_DOMAIN_NAME
-  OS_PROJECT_NAME
-  OS_IDENTITY_API_VERSION
+  OS_*
+  TEST_*
 
 [testenv:build]
 commands = charmcraft build
@@ -76,6 +68,6 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite --keep-faulty-model {posargs}
+commands = functest-run-suite {posargs:--keep-faulty-model}
 deps =
   -r{toxinidir}/tests/functional/requirements.txt


### PR DESCRIPTION
Used zaza from master and fix bundles and overlays. Switch to use 1.28/stable channel for k8s charms, since from 1.29 there is no `kube-api-endpoint` relation. Since lxd-profile.yaml is provided in `kubernetes-worker` and `kubernetes-control-plane` there is no need to run func test on top of OpenStack. Switching CI to run on ~~official GitHub~~ our self-hosted runners and LXD, instead of external OpenStack.

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.